### PR TITLE
[codex] add Elasticsearch agent memory sample

### DIFF
--- a/AI-Modeling-Notebooks/19-ElasticSearch/Agent-Memory/1_write_memory.py
+++ b/AI-Modeling-Notebooks/19-ElasticSearch/Agent-Memory/1_write_memory.py
@@ -1,0 +1,32 @@
+from memory_store import EPISODIC_INDEX, create_client, write_memory
+
+
+def write_sample_episodic_memory(client=None) -> str:
+    """
+    Store the raw user turn as episodic memory.
+
+    This sample writes with refresh=True inside memory_store.write_memory so
+    the agent can recall the just-written document in the same turn. That is a
+    good learning default, but it trades write throughput for recall
+    consistency. In a high-write production agent, prefer async indexing plus a
+    small agent-side "just-written" register that injects new facts into the
+    LLM context until Elasticsearch's native refresh catches up.
+    """
+    client = client or create_client()
+    return write_memory(
+        client,
+        {
+            "user_id": "bob",
+            "text": "Original user message: Help me check the deployment logs from last Friday.",
+            "memory_type": "message",
+            "title": "User requested deployment logs",
+            "timestamp": "2026-06-19T10:30:00+08:00",
+            "metadata": {"conversation_id": "demo-agent-memory"},
+        },
+        index=EPISODIC_INDEX,
+    )
+
+
+if __name__ == "__main__":
+    memory_id = write_sample_episodic_memory()
+    print(f"Wrote episodic memory: {memory_id}")

--- a/AI-Modeling-Notebooks/19-ElasticSearch/Agent-Memory/2_reranker.py
+++ b/AI-Modeling-Notebooks/19-ElasticSearch/Agent-Memory/2_reranker.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any
+
+from memory_store import MEMORY_INDICES, build_recall_query, recall_memory
+
+
+def recall_memory_with_optional_rerank(
+    client: Any,
+    user_id: str,
+    query: str,
+    k: int = 5,
+    include_superseded: bool = False,
+) -> list[dict[str, Any]]:
+    """
+    Recall different memory types with one Elasticsearch query.
+
+    The important design point is that recall searches across the memory index
+    list in a single request. One user question can therefore return:
+
+    - episodic memory: raw conversation events and user turns
+    - semantic memory: stable facts, preferences, and profile knowledge
+    - procedural memory: reusable steps for tasks the agent has learned
+
+    Local Elasticsearch installs usually do not have Jina embedding and
+    reranker inference endpoints configured. The code first tries a lightweight
+    rescore query shape, then degrades to the BM25 recall helper.
+    """
+    try:
+        overfetch_k = max(k * 8, 40)
+        first_pass = client.search(
+            index=MEMORY_INDICES,
+            body=build_recall_query(user_id, query, include_superseded=include_superseded),
+            size=overfetch_k,
+        )
+        ids = [hit["_id"] for hit in first_pass.get("hits", {}).get("hits", [])]
+        if not ids:
+            return []
+
+        reranked = client.search(
+            index=MEMORY_INDICES,
+            body={
+                "query": {"ids": {"values": ids}},
+                "rescore": {
+                    "window_size": overfetch_k,
+                    "query": {
+                        "rescore_query": {
+                            "multi_match": {
+                                "query": query,
+                                "fields": ["text^4", "title^2", "trigger_text"],
+                            }
+                        },
+                        "query_weight": 0.7,
+                        "rescore_query_weight": 1.3,
+                    },
+                },
+            },
+            size=k,
+        )
+        return [
+            {
+                "id": hit["_id"],
+                "index": hit["_index"],
+                "text": hit["_source"].get("text", ""),
+                "score": hit.get("_score", 0.0),
+                "source": "rescore",
+            }
+            for hit in reranked.get("hits", {}).get("hits", [])[:k]
+        ]
+    except Exception as exc:
+        print(f"[WARN] Rerank path failed, falling back to BM25 recall: {exc}")
+        return recall_memory(
+            client,
+            user_id,
+            query,
+            k=k,
+            include_superseded=include_superseded,
+        )

--- a/AI-Modeling-Notebooks/19-ElasticSearch/Agent-Memory/3_verbatim_pre_recall.py
+++ b/AI-Modeling-Notebooks/19-ElasticSearch/Agent-Memory/3_verbatim_pre_recall.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from memory_store import recall_memory
+
+
+class MemoryAwareAgent:
+    def __init__(self, client: Any, llm: Any, user_id: str):
+        self.client = client
+        self.llm = llm
+        self.user_id = user_id
+        self.messages: list[dict[str, Any]] = []
+
+    def run_turn(self, user_message: str, turn_id: str) -> str:
+        """
+        Run recall before the LLM has a chance to rewrite the user's words.
+
+        This is the key BM25 contribution. LLMs are good rewriting machines:
+        a message like "postgres v15.3 + pgvector 0.5.1" may be normalized into
+        "PostgreSQL database" before a tool call. That is often fine for dense
+        retrieval, but it destroys exact tokens that BM25 can match directly.
+
+        Verbatim pre-recall sends the original user message to Elasticsearch
+        first, preserving version numbers, error codes, model names, and other
+        high-signal tokens.
+        """
+        pre_recall_call_id = f"call_pre_{turn_id[:8]}"
+        pre_recall_result = recall_memory(self.client, self.user_id, user_message, k=5)
+
+        self.messages.append(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": pre_recall_call_id,
+                        "function": {
+                            "name": "recall_memory",
+                            "arguments": json.dumps({"query": user_message}),
+                        },
+                    }
+                ],
+            }
+        )
+        self.messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": pre_recall_call_id,
+                "name": "recall_memory",
+                "content": json.dumps(pre_recall_result, ensure_ascii=False),
+            }
+        )
+        self.messages.append({"role": "user", "content": user_message})
+        return self.llm.chat(self.messages)

--- a/AI-Modeling-Notebooks/19-ElasticSearch/Agent-Memory/4_consolidation.py
+++ b/AI-Modeling-Notebooks/19-ElasticSearch/Agent-Memory/4_consolidation.py
@@ -1,0 +1,126 @@
+import json
+from typing import Any
+
+from memory_store import PROCEDURAL_INDEX, SEMANTIC_INDEX, write_memory
+
+
+# Core consolidation prompt schema. In production, run this as a background
+# batch job instead of calling it after every agent turn; otherwise each turn
+# needs two LLM inferences, one for the reply and one for consolidation.
+CONSOLIDATION_PROMPT = """
+You are analyzing recent episodic memories to extract structured knowledge.
+
+RECENT EPISODIC EVENTS (last 30):
+{episodic_events}
+
+EXISTING SEMANTIC FACTS (~50):
+{existing_facts}
+
+EXISTING PROCEDURALS (~20):
+{existing_procedurals}
+
+Output JSON:
+{
+  "new_facts": [
+    {
+      "fact": "...",
+      "confidence": 0.0-1.0,
+      "supporting_episode_ids": ["epi_123", "epi_145"],
+      "supersedes_id": null
+    }
+  ],
+  "new_procedures": [
+    {
+      "name": "...",
+      "steps": ["step 1", "step 2"],
+      "confidence": 0.0-1.0,
+      "trigger_text": "when user asks about deployment"
+    }
+  ],
+  "procedural_updates": [
+    {
+      "procedural_id": "proc_056",
+      "success_delta": 1,
+      "failure_delta": 0,
+      "refined_steps": null
+    }
+  ]
+}
+
+Rules:
+- Confidence >= 0.8 to create new procedural
+- Mark supersedes_id when new fact contradicts existing one
+- Include supporting_episode_ids for traceability
+"""
+
+DEFAULT_CONSOLIDATION_WINDOW_HOURS = 24
+DEFAULT_MIN_EPISODIC_EVENTS_FOR_DYNAMIC_RUN = 100
+
+def build_consolidation_prompt(
+    episodic_events: list[dict[str, Any]],
+    existing_facts: list[dict[str, Any]],
+    existing_procedurals: list[dict[str, Any]],
+) -> str:
+    """
+    Build the prompt for a background consolidation pass.
+
+    Running consolidation after every user turn doubles LLM inference cost: the
+    system pays once to answer and once to extract durable memories. A cheaper
+    production pattern is to accumulate episodic events during the day and run
+    one consolidation batch at night.
+
+    That trades about 24 hours of memory freshness for roughly half the LLM
+    inference cost. At higher traffic, trigger additional runs when the number
+    of new episodic events in the last 24 hours exceeds a chosen threshold.
+    """
+    return CONSOLIDATION_PROMPT.format(
+        episodic_events=json.dumps(episodic_events, indent=2),
+        existing_facts=json.dumps(existing_facts, indent=2),
+        existing_procedurals=json.dumps(existing_procedurals, indent=2),
+    )
+
+
+def apply_consolidation_result(
+    client: Any,
+    user_id: str,
+    consolidation: dict[str, Any],
+) -> dict[str, list[str]]:
+    created = {"facts": [], "procedures": []}
+
+    for fact in consolidation.get("new_facts", []):
+        if fact.get("confidence", 0) < 0.5:
+            continue
+        fact_id = write_memory(
+            client,
+            {
+                "user_id": user_id,
+                "text": fact["fact"],
+                "memory_type": "semantic",
+                "confidence": fact.get("confidence", 0.5),
+                "supporting_episode_ids": fact.get("supporting_episode_ids", []),
+                "supersedes": fact.get("supersedes_id"),
+            },
+            SEMANTIC_INDEX,
+        )
+        created["facts"].append(fact_id)
+
+    for procedure in consolidation.get("new_procedures", []):
+        if procedure.get("confidence", 0) < 0.8:
+            continue
+        procedure_id = write_memory(
+            client,
+            {
+                "user_id": user_id,
+                "text": procedure["name"],
+                "memory_type": "procedural",
+                "confidence": procedure.get("confidence", 0.8),
+                "steps": procedure.get("steps", []),
+                "trigger_text": procedure.get("trigger_text", procedure["name"]),
+                "success_count": 0,
+                "failure_count": 0,
+            },
+            PROCEDURAL_INDEX,
+        )
+        created["procedures"].append(procedure_id)
+
+    return created

--- a/AI-Modeling-Notebooks/19-ElasticSearch/Agent-Memory/5_soft_supersession.py
+++ b/AI-Modeling-Notebooks/19-ElasticSearch/Agent-Memory/5_soft_supersession.py
@@ -1,0 +1,18 @@
+from memory_store import supersede_fact
+
+
+def correct_stale_fact(client, user_id: str, old_fact_id: str) -> str:
+    """
+    Replace a stale fact by linking a new fact to the old one.
+
+    The old fact is never deleted. It is marked as superseded, which preserves
+    the full version chain for audits or historical questions like "what was
+    this user's database preference three years ago?"
+    """
+    return supersede_fact(
+        client,
+        user_id=user_id,
+        old_fact_id=old_fact_id,
+        new_text="Bob prefers daily deployment summaries from Kibana.",
+        contradiction_type="harsh",
+    )

--- a/AI-Modeling-Notebooks/19-ElasticSearch/Agent-Memory/6_gbrain.py
+++ b/AI-Modeling-Notebooks/19-ElasticSearch/Agent-Memory/6_gbrain.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+from memory_store import (
+    EPISODIC_INDEX,
+    PROCEDURAL_INDEX,
+    SEMANTIC_INDEX,
+    create_client,
+    ensure_memory_indices,
+    recall_memory,
+    supersede_fact,
+    write_memory,
+)
+
+
+def seed_deployment_memories(client: Any, user_id: str = "bob") -> dict[str, str]:
+    old_fact_id = write_memory(
+        client,
+        {
+            "user_id": user_id,
+            "text": "Bob prefers weekly deployment summaries from Grafana.",
+            "memory_type": "semantic",
+            "title": "Outdated deployment summary preference",
+            "confidence": 0.7,
+        },
+        SEMANTIC_INDEX,
+    )
+    concise_fact_id = write_memory(
+        client,
+        {
+            "user_id": user_id,
+            "text": "Bob prefers concise deployment summaries with action items first.",
+            "memory_type": "semantic",
+            "title": "Deployment summary style",
+            "confidence": 0.95,
+        },
+        SEMANTIC_INDEX,
+    )
+    episode_id = write_memory(
+        client,
+        {
+            "user_id": user_id,
+            "text": "Bob asked to check failed deployment logs for the payments API last Friday.",
+            "memory_type": "message",
+            "title": "Payments API deployment log request",
+        },
+        EPISODIC_INDEX,
+    )
+    procedure_id = write_memory(
+        client,
+        {
+            "user_id": user_id,
+            "text": "Deployment log investigation workflow",
+            "memory_type": "procedural",
+            "title": "Investigate failed deployment",
+            "trigger_text": "when Bob asks about failed deployment logs",
+            "steps": [
+                "Check failed pods and recent error spikes.",
+                "Compare the release diff for the failing service.",
+                "Summarize impact, likely cause, and action items.",
+            ],
+            "confidence": 0.9,
+        },
+        PROCEDURAL_INDEX,
+    )
+    return {
+        "old_fact_id": old_fact_id,
+        "concise_fact_id": concise_fact_id,
+        "episode_id": episode_id,
+        "procedure_id": procedure_id,
+    }
+
+
+def answer_with_memory(user_message: str, memories: list[dict[str, Any]]) -> str:
+    memory_text = " ".join(memory["text"] for memory in memories)
+    source = "Kibana" if "Kibana" in memory_text else "the deployment logs"
+    style = "concise" if "concise" in memory_text else "short"
+    return (
+        f"I will check {source} for the failed deployment and keep the summary {style}: "
+        "impact first, likely cause second, and action items last."
+    )
+
+
+def run_deployment_memory_use_case(client: Any | None = None) -> dict[str, Any]:
+    client = client or create_client()
+    user_id = "bob"
+    seeded = seed_deployment_memories(client, user_id=user_id)
+
+    new_fact_id = supersede_fact(
+        client,
+        user_id=user_id,
+        old_fact_id=seeded["old_fact_id"],
+        new_text="Bob prefers daily deployment summaries from Kibana.",
+        contradiction_type="harsh",
+    )
+
+    user_message = "Can you check the failed deployment logs and summarize what changed?"
+    recalled = recall_memory(client, user_id, user_message, k=5)
+    assistant_response = answer_with_memory(user_message, recalled)
+    return {
+        "user_message": user_message,
+        "recalled_memories": recalled,
+        "assistant_response": assistant_response,
+        "new_fact_id": new_fact_id,
+    }
+
+
+def run_live_elasticsearch_demo(es_url: str = "http://localhost:9200", recreate: bool = False) -> dict[str, Any]:
+    client = create_client(es_url)
+    ensure_memory_indices(client, recreate=recreate)
+    return run_deployment_memory_use_case(client)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run the Agent Memory demo against Elasticsearch.")
+    parser.add_argument("--es-url", default="http://localhost:9200")
+    parser.add_argument(
+        "--recreate",
+        action="store_true",
+        help="Delete and recreate the atlas-* demo indices before seeding memories.",
+    )
+    args = parser.parse_args()
+
+    result = run_live_elasticsearch_demo(es_url=args.es_url, recreate=args.recreate)
+    print(result["assistant_response"])
+    print("\nRecalled memories:")
+    for memory in result["recalled_memories"]:
+        print(f"- [{memory['memory_type']}] {memory['text']}")

--- a/AI-Modeling-Notebooks/19-ElasticSearch/Agent-Memory/README.md
+++ b/AI-Modeling-Notebooks/19-ElasticSearch/Agent-Memory/README.md
@@ -1,0 +1,220 @@
+# Agent Memory with Elasticsearch
+
+This folder is a runnable Elasticsearch-backed memory sample for an agent.
+
+It demonstrates:
+
+- same-turn memory writes with `refresh=True`
+- BM25 recall that can return episodic, semantic, and procedural memories in one query
+- soft supersession for stale semantic facts
+- verbatim pre-recall before an LLM call
+- a concrete deployment-log assistant use case
+
+## Run Elasticsearch
+
+From `19-ElasticSearch`, start the local Elasticsearch container described in the parent README:
+
+```bash
+docker run -d \
+  --name elasticsearch \
+  -p 9200:9200 \
+  -p 9300:9300 \
+  -e "discovery.type=single-node" \
+  -e "xpack.security.enabled=false" \
+  -e "ES_JAVA_OPTS=-Xms1g -Xmx1g" \
+  docker.elastic.co/elasticsearch/elasticsearch:8.11.3
+```
+
+Confirm it is reachable:
+
+```bash
+curl http://localhost:9200
+```
+
+## Run The Use Case
+
+```bash
+python 19-ElasticSearch/Agent-Memory/6_gbrain.py --recreate
+```
+
+`--recreate` deletes and recreates the four demo indices:
+
+- `atlas-episodic`
+- `atlas-semantic`
+- `atlas-procedural`
+- `atlas-catalog`
+
+The demo seeds Bob's deployment-log memories, supersedes an outdated Grafana preference with a Kibana preference, recalls relevant memories from Elasticsearch, and prints the assistant response.
+
+## Multi-Tenant Isolation With DLS
+
+Atlas-style memory is multi-tenant by default: each user should only see their own memories plus shared catalog documents. Do not rely only on application code such as `if user_id == request.user_id`; that check is easy to forget in one query path.
+
+Use Elasticsearch Document-Level Security as the primary isolation boundary. DLS requires a security-enabled Elasticsearch cluster and an administrative credential for bootstrapping users. Each user gets an API key whose role descriptor includes this DLS query:
+
+```json
+{
+  "bool": {
+    "should": [
+      {"term": {"user_id": "bob"}},
+      {"bool": {"must_not": {"exists": {"field": "user_id"}}}}
+    ],
+    "minimum_should_match": 1
+  }
+}
+```
+
+That allows documents owned by `bob` and documents without a `user_id`, which are treated as shared catalog records. The sample builds that role descriptor in `build_user_api_key_role_descriptor(...)` and mints keys through `bootstrap_users.py`:
+
+```bash
+python 19-ElasticSearch/Agent-Memory/bootstrap_users.py bob alice
+```
+
+At request time, create the Elasticsearch client with that user's API key:
+
+```python
+client = create_client("http://localhost:9200", api_key=("api-key-id", "api-key-secret"))
+```
+
+The application query still includes `_user_or_catalog_filter` as defense in depth. It is redundant on purpose; DLS protects the cluster, and the app filter protects against accidental broad queries during development.
+
+Catalog documents participate in ranking through `CATALOG_SOURCE_PRIOR = 0.85`. This is a soft score prior, not a hard routing rule. Catalog hits are slightly de-boosted, but if a catalog document is clearly more relevant, Elasticsearch scoring or a downstream reranker can still select it.
+
+## Step 2: One Query, Three Memory Types
+
+The recall step sends one Elasticsearch search request across the memory indices. That single query can return different kinds of memory together:
+
+- `episodic`: raw conversation events, such as a recent user request
+- `semantic`: stable facts and preferences, such as the user's preferred summary style
+- `procedural`: learned task steps, such as how to investigate a failed deployment
+
+The agent does not need three separate retrieval calls. It can ask once, then use each hit's `memory_type` field to decide how to place the result in the LLM context.
+
+Example response shape:
+
+```json
+[
+  {
+    "memory_type": "message",
+    "text": "Bob asked to check failed deployment logs for the payments API last Friday."
+  },
+  {
+    "memory_type": "semantic",
+    "text": "Bob prefers concise deployment summaries with action items first."
+  },
+  {
+    "memory_type": "procedural",
+    "text": "Deployment log investigation workflow",
+    "metadata": {
+      "steps": ["check failed pods", "compare release diff", "summarize impact"]
+    }
+  }
+]
+```
+
+## Step 3: Verbatim Pre-Recall Protects Exact Tokens
+
+The BM25 leg is valuable because it preserves exact-token retrieval. LLMs are trained to rewrite and summarize, so a user message containing versions, error codes, or model names can be generalized before the agent calls `recall_memory`.
+
+Example:
+
+```text
+User text:      postgres v15.3 + pgvector 0.5.1
+LLM rewrite:    PostgreSQL database
+```
+
+If the rewritten query is sent to Elasticsearch, the exact tokens `v15.3` and `pgvector 0.5.1` may never match the indexed memory. Verbatim pre-recall bypasses that rewrite layer by sending the original user message directly to BM25 before the LLM produces a tool-call query.
+
+The retrieval roles are split intentionally:
+
+- BM25 captures exact tokens such as versions, error codes, product names, and model numbers.
+- Dense retrieval captures semantic similarity when the wording changes.
+- Extra LLM paraphrase expansion can add noise once those two legs already exist.
+
+In ablation testing, generating two additional paraphrases with an LLM and fusing results after document-ID deduplication reduced performance. The likely reason is that BM25 already captures exact wording and dense retrieval already captures semantic rewrites; an extra paraphrase stage mostly introduces lower-precision matches.
+
+## Step 4: Run Consolidation As A Batch Job
+
+Consolidation turns raw episodic events into durable semantic facts and procedural memories. It is tempting to run consolidation at the end of every conversation turn, but that doubles LLM inference cost:
+
+```text
+one turn = one LLM call to answer + one LLM call to consolidate
+```
+
+For production systems, run consolidation in the background instead. A practical default is a nightly batch: accumulate one day of episodic events, then run a single consolidation job during off-peak hours.
+
+The tradeoff is explicit:
+
+- Memory freshness is delayed by about 24 hours.
+- LLM consolidation cost drops by roughly half compared with per-turn consolidation.
+- Agent replies stay fast because consolidation no longer blocks the active turn.
+
+When traffic grows, make the batch schedule dynamic. For example, run consolidation when the number of new episodic events in the last 24 hours exceeds `N`; high event density automatically increases consolidation frequency, while quiet periods keep cost low.
+
+## Step 5: Supersede Facts, Do Not Delete Them
+
+Soft supersession keeps every version of a semantic fact. Updating a fact creates a chain:
+
+```text
+abc -> xyz -> pqr -> ...
+```
+
+Each old document is marked with `superseded_by`; each new document points back with `supersedes`. The default recall path hides superseded facts so the agent sees the current version. If you need the historical chain, call:
+
+```python
+recall_memory(client, user_id, query, include_superseded=True)
+```
+
+That lets you answer audit-style questions such as "what was this user's database preference three years ago?"
+
+Harsh contradictions get a small confidence penalty. If the user says "I never said that," the replacement fact is stored at `0.9` confidence instead of `1.0`. The system treats the correction as likely true, but leaves room for later confirmation before restoring full confidence.
+
+Consolidation is not mandatory in every deployment. For a small internal bot with 20 users, episodic memory plus manually marked semantic facts can be enough; asking users to say "remember this preference" may be cheaper than building an automatic extraction pipeline.
+
+Atlas-style consolidation is designed for invisible memory management. If users do not know the memory system exists and will not manually maintain semantic facts, skipping consolidation effectively means you do not have a semantic layer.
+
+## Production Notes
+
+### Debug Painless scoring with `_explain`
+
+Painless scripts are hard to debug from application code. A practical workflow is to reproduce the scoring query in Kibana Dev Tools with the Elasticsearch `_explain` API:
+
+```http
+GET atlas-semantic/_explain/<document_id>
+{
+  "query": {
+    "function_score": {
+      "query": {
+        "multi_match": {
+          "query": "failed deployment logs",
+          "fields": ["text^3", "title^2", "trigger_text"]
+        }
+      },
+      "script_score": {
+        "script": {
+          "source": "return _score * params.decay;",
+          "params": {
+            "decay": 0.72
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Feed `_explain` the query, document ID, and concrete script parameters. The response breaks scoring into explanation sections, so you can inspect each boost or decay multiplier instead of trying to print intermediate values from inside the application.
+
+### Treat `refresh=True` as a consistency tradeoff
+
+`refresh=True` makes newly written memories searchable immediately, which is useful for same-turn agent recall. The cost is lower write throughput because each write forces a refresh.
+
+For high-write production workloads, such as hundreds of memory writes per second, move to async indexing and keep an agent-layer just-written register. The register should temporarily hold facts written during the current turn and inject them into the LLM context until Elasticsearch's native refresh interval makes those documents searchable.
+
+## Fast Tests
+
+The tests use a fake client so they can validate the Elasticsearch request shapes without requiring Docker:
+
+```bash
+python -m pytest 19-ElasticSearch/Agent-Memory/test_agent_memory.py -q
+```

--- a/AI-Modeling-Notebooks/19-ElasticSearch/Agent-Memory/bootstrap_users.py
+++ b/AI-Modeling-Notebooks/19-ElasticSearch/Agent-Memory/bootstrap_users.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+from memory_store import create_client, create_user_api_key, ensure_memory_indices
+
+
+def bootstrap_users(es_url: str, user_ids: list[str]) -> dict[str, dict]:
+    """
+    Create DLS-scoped Elasticsearch API keys for Agent Memory users.
+
+    Run this with an administrative Elasticsearch client. Each generated API
+    key includes a role descriptor that allows the user to read only:
+
+    - documents whose user_id matches that user
+    - shared catalog documents that do not have a user_id field
+
+    The application should use the returned per-user key for memory reads and
+    writes instead of sharing one broad cluster credential across tenants.
+    """
+    if not user_ids:
+        raise ValueError("At least one user_id is required.")
+
+    client = create_client(es_url)
+    ensure_memory_indices(client)
+    return {user_id: create_user_api_key(client, user_id) for user_id in user_ids}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create DLS-scoped Agent Memory API keys.")
+    parser.add_argument("--es-url", default="http://localhost:9200")
+    parser.add_argument("user_ids", nargs="+", help="User IDs to bootstrap, such as bob alice")
+    args = parser.parse_args()
+
+    api_keys = bootstrap_users(args.es_url, args.user_ids)
+    print(json.dumps(api_keys, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/AI-Modeling-Notebooks/19-ElasticSearch/Agent-Memory/memory_store.py
+++ b/AI-Modeling-Notebooks/19-ElasticSearch/Agent-Memory/memory_store.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+EPISODIC_INDEX = "atlas-episodic"
+SEMANTIC_INDEX = "atlas-semantic"
+PROCEDURAL_INDEX = "atlas-procedural"
+CATALOG_INDEX = "atlas-catalog"
+MEMORY_INDICES = [EPISODIC_INDEX, SEMANTIC_INDEX, PROCEDURAL_INDEX, CATALOG_INDEX]
+CATALOG_SOURCE_PRIOR = 0.85
+
+INDEX_SETTINGS = {
+    "number_of_shards": 1,
+    "number_of_replicas": 0,
+}
+
+COMMON_PROPERTIES = {
+    "user_id": {"type": "keyword"},
+    "text": {"type": "text"},
+    "memory_type": {"type": "keyword"},
+    "title": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
+    "timestamp": {"type": "date", "ignore_malformed": True},
+    "metadata": {"type": "object", "enabled": True},
+    "index_name": {"type": "keyword"},
+    "confidence": {"type": "float"},
+    "supersedes": {"type": "keyword"},
+    "superseded_by": {"type": "keyword"},
+    "superseded_at": {"type": "date", "ignore_malformed": True},
+    "supporting_episode_ids": {"type": "keyword"},
+    "last_used_at": {"type": "date", "ignore_malformed": True},
+    "use_count": {"type": "integer"},
+}
+
+INDEX_MAPPINGS = {
+    EPISODIC_INDEX: {"properties": COMMON_PROPERTIES},
+    SEMANTIC_INDEX: {"properties": COMMON_PROPERTIES},
+    PROCEDURAL_INDEX: {
+        "properties": {
+            **COMMON_PROPERTIES,
+            "steps": {"type": "text"},
+            "trigger_text": {"type": "text"},
+            "success_count": {"type": "integer"},
+            "failure_count": {"type": "integer"},
+        }
+    },
+    CATALOG_INDEX: {
+        "properties": {
+            **COMMON_PROPERTIES,
+            "name": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
+            "description": {"type": "text"},
+        }
+    },
+}
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def create_client(url: str = "http://localhost:9200", api_key: Any | None = None) -> Any:
+    from elasticsearch import Elasticsearch
+
+    if api_key is None:
+        return Elasticsearch(url)
+    return Elasticsearch(url, api_key=api_key)
+
+
+def build_dls_query(user_id: str) -> dict[str, Any]:
+    """
+    Cluster-level DLS query for one user's API key.
+
+    User-owned memories must match user_id. Catalog documents are shared by
+    omitting user_id, so they remain visible to every tenant.
+    """
+    return {
+        "bool": {
+            "should": [
+                {"term": {"user_id": user_id}},
+                {"bool": {"must_not": {"exists": {"field": "user_id"}}}},
+            ],
+            "minimum_should_match": 1,
+        }
+    }
+
+
+def build_user_api_key_role_descriptor(user_id: str) -> dict[str, Any]:
+    return {
+        f"atlas_memory_{user_id}": {
+            "indices": [
+                {
+                    "names": MEMORY_INDICES,
+                    "privileges": ["read", "view_index_metadata"],
+                    "query": build_dls_query(user_id),
+                }
+            ]
+        }
+    }
+
+
+def create_user_api_key(client: Any, user_id: str) -> dict[str, Any]:
+    """
+    Mint one Elasticsearch API key scoped by Document-Level Security.
+
+    Call this from an admin/bootstrap client. The returned API key should be
+    used by the application when serving that specific user, so Elasticsearch
+    enforces tenant isolation before application code receives any hits.
+    """
+    return client.security.create_api_key(
+        name=f"atlas-memory-{user_id}",
+        role_descriptors=build_user_api_key_role_descriptor(user_id),
+        metadata={"user_id": user_id, "purpose": "atlas-memory"},
+    )
+
+
+def ensure_memory_indices(client: Any, recreate: bool = False) -> list[str]:
+    """
+    Create the Elasticsearch indices used by the memory sample.
+
+    Set recreate=True for local demos when you want deterministic output and do
+    not mind deleting the four atlas-* sample indices first.
+    """
+    created = []
+    for index in MEMORY_INDICES:
+        if recreate:
+            client.indices.delete(index=index, ignore_unavailable=True)
+
+        if _index_exists(client, index):
+            continue
+
+        client.indices.create(
+            index=index,
+            settings=INDEX_SETTINGS,
+            mappings=INDEX_MAPPINGS[index],
+        )
+        created.append(index)
+    return created
+
+
+def build_memory_document(doc: dict[str, Any], index: str) -> dict[str, Any]:
+    timestamp = doc.get("timestamp", utc_now_iso())
+    memory_type = doc.get("memory_type") or _memory_type_from_index(index)
+    stored = {
+        "user_id": doc.get("user_id"),
+        "text": doc["text"],
+        "memory_type": memory_type,
+        "title": doc.get("title", ""),
+        "timestamp": timestamp,
+        "metadata": doc.get("metadata", {}),
+        "index_name": _index_alias(index),
+    }
+
+    for field in (
+        "confidence",
+        "supersedes",
+        "superseded_by",
+        "superseded_at",
+        "supporting_episode_ids",
+        "steps",
+        "trigger_text",
+        "success_count",
+        "failure_count",
+        "last_used_at",
+        "use_count",
+    ):
+        if field in doc:
+            stored[field] = doc[field]
+
+    return {key: value for key, value in stored.items() if value is not None}
+
+
+def write_memory(client: Any, doc: dict[str, Any], index: str) -> str:
+    """
+    Write one memory document and refresh immediately for same-turn recall.
+
+    The sample uses Elasticsearch as a search-optimized memory layer, so writes
+    preserve optional semantic/procedural fields instead of flattening every
+    memory into only text and metadata.
+    """
+    body = build_memory_document(doc, index)
+    try:
+        resp = client.index(index=index, document=body, refresh=True)
+    except TypeError:
+        resp = client.index(index=index, body=body, refresh=True)
+    return resp["_id"]
+
+
+def build_recall_query(
+    user_id: str,
+    query: str,
+    include_superseded: bool = False,
+) -> dict[str, Any]:
+    bool_query: dict[str, Any] = {
+        "should": [
+            {
+                "multi_match": {
+                    "query": query,
+                    "fields": ["text^3", "title^2", "name", "description", "trigger_text"],
+                    "type": "best_fields",
+                }
+            }
+        ],
+        "filter": [build_user_or_catalog_filter(user_id)],
+    }
+
+    if not include_superseded:
+        bool_query["must_not"] = [{"exists": {"field": "superseded_by"}}]
+
+    return {
+        "query": {
+            "function_score": {
+                "query": {"bool": bool_query},
+                "functions": [
+                    {
+                        "filter": {"term": {"_index": CATALOG_INDEX}},
+                        "weight": CATALOG_SOURCE_PRIOR,
+                    }
+                ],
+                "score_mode": "multiply",
+                "boost_mode": "multiply",
+            }
+        }
+    }
+
+
+def build_user_or_catalog_filter(user_id: str) -> dict[str, Any]:
+    """
+    Redundant app-layer tenant filter.
+
+    DLS should enforce isolation in the cluster itself. This filter repeats the
+    same user-or-catalog rule in application queries as defense in depth.
+    """
+    return {
+        "bool": {
+            "should": [
+                {"term": {"user_id": user_id}},
+                {"bool": {"must_not": [{"exists": {"field": "user_id"}}]}},
+            ],
+            "minimum_should_match": 1,
+        }
+    }
+
+
+def recall_memory(
+    client: Any,
+    user_id: str,
+    query: str,
+    k: int = 5,
+    include_superseded: bool = False,
+) -> list[dict[str, Any]]:
+    """
+    Recall memories with a robust local-first search path.
+
+    A production cluster can extend this query with RRF, dense retrieval, and a
+    cross-encoder reranker. This sample keeps the default path runnable on a
+    plain Elasticsearch install by using BM25 and metadata filters.
+    """
+    body = build_recall_query(user_id, query, include_superseded=include_superseded)
+    resp = client.search(index=MEMORY_INDICES, body=body, size=k)
+    return [_format_hit(hit, source="bm25") for hit in resp.get("hits", {}).get("hits", [])[:k]]
+
+
+def supersede_fact(
+    client: Any,
+    user_id: str,
+    old_fact_id: str,
+    new_text: str,
+    contradiction_type: str = "natural",
+) -> str:
+    """
+    Add a new semantic fact without deleting the old one.
+
+    Supersession forms an audit chain of arbitrary length:
+    old -> newer -> newest. The old document receives superseded_by, and the
+    new document receives supersedes. Use recall_memory(...,
+    include_superseded=True) when you need historical preferences or the full
+    chain for debugging.
+
+    A harsh contradiction is an explicit user correction, such as "I never said
+    that." The new fact gets a small confidence penalty until future
+    interactions confirm it.
+    """
+    confidence = 1.0
+    if contradiction_type == "harsh":
+        confidence -= 0.1
+
+    new_id = write_memory(
+        client,
+        {
+            "user_id": user_id,
+            "text": new_text,
+            "memory_type": "semantic",
+            "confidence": confidence,
+            "supersedes": old_fact_id,
+            "timestamp": "now",
+        },
+        index=SEMANTIC_INDEX,
+    )
+
+    client.update(
+        index=SEMANTIC_INDEX,
+        id=old_fact_id,
+        body={"doc": {"superseded_by": new_id, "superseded_at": "now"}},
+    )
+    return new_id
+
+
+def _format_hit(hit: dict[str, Any], source: str) -> dict[str, Any]:
+    doc = hit.get("_source", {})
+    return {
+        "id": hit.get("_id"),
+        "index": hit.get("_index"),
+        "text": doc.get("text", ""),
+        "title": doc.get("title", ""),
+        "memory_type": doc.get("memory_type", ""),
+        "score": hit.get("_score", 0.0),
+        "source": source,
+        "metadata": doc.get("metadata", {}),
+        "steps": doc.get("steps", []),
+        "trigger_text": doc.get("trigger_text", ""),
+    }
+
+
+def _index_alias(index: str) -> str:
+    return index.replace("atlas-", "")
+
+
+def _memory_type_from_index(index: str) -> str:
+    return _index_alias(index)
+
+
+def _index_exists(client: Any, index: str) -> bool:
+    response = client.indices.exists(index=index)
+    if isinstance(response, bool):
+        return response
+    return bool(response)

--- a/AI-Modeling-Notebooks/19-ElasticSearch/Agent-Memory/test_agent_memory.py
+++ b/AI-Modeling-Notebooks/19-ElasticSearch/Agent-Memory/test_agent_memory.py
@@ -1,0 +1,380 @@
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+
+AGENT_MEMORY_DIR = Path(__file__).resolve().parent
+
+
+def load_module(module_name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(module_name, AGENT_MEMORY_DIR / filename)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+memory_store = load_module("memory_store", "memory_store.py")
+bootstrap_users_module = load_module("bootstrap_users", "bootstrap_users.py")
+gbrain = load_module("gbrain", "6_gbrain.py")
+pre_recall = load_module("pre_recall", "3_verbatim_pre_recall.py")
+
+
+def recall_bool_query(search_body):
+    query = search_body["query"]
+    if "function_score" in query:
+        return query["function_score"]["query"]["bool"]
+    return query["bool"]
+
+
+class FakeElasticsearch:
+    def __init__(self):
+        self.documents = {}
+        self.updated = []
+        self.index_calls = []
+        self.search_calls = []
+        self.indices = FakeIndices()
+        self.counter = 0
+
+    def index(self, index, document=None, body=None, refresh=False):
+        self.counter += 1
+        doc_id = f"{index}-{self.counter}"
+        source = document if document is not None else body
+        source = dict(source)
+        self.documents[(index, doc_id)] = source
+        self.index_calls.append({"index": index, "id": doc_id, "document": source, "refresh": refresh})
+        return {"_id": doc_id}
+
+    def update(self, index, id, body):
+        self.updated.append({"index": index, "id": id, "body": body})
+        current = self.documents.get((index, id), {})
+        current.update(body["doc"])
+        self.documents[(index, id)] = current
+        return {"result": "updated"}
+
+    def search(self, index, body, size=10):
+        self.search_calls.append({"index": index, "body": body, "size": size})
+        indices = index if isinstance(index, list) else [index]
+        hits = []
+        include_superseded = "must_not" not in recall_bool_query(body)
+        for (doc_index, doc_id), source in self.documents.items():
+            if doc_index not in indices:
+                continue
+            if source.get("superseded_by") and not include_superseded:
+                continue
+            hits.append({"_id": doc_id, "_index": doc_index, "_source": source, "_score": 1.0})
+        return {"hits": {"hits": hits[:size]}}
+
+
+class FakeIndices:
+    def __init__(self):
+        self.created = {}
+        self.deleted = []
+
+    def exists(self, index):
+        return index in self.created
+
+    def create(self, index, mappings=None, settings=None):
+        self.created[index] = {"mappings": mappings, "settings": settings}
+        return {"acknowledged": True}
+
+    def delete(self, index, ignore_unavailable=False):
+        self.deleted.append({"index": index, "ignore_unavailable": ignore_unavailable})
+        self.created.pop(index, None)
+        return {"acknowledged": True}
+
+
+class FakeSecurity:
+    def __init__(self):
+        self.api_key_requests = []
+
+    def create_api_key(self, name, role_descriptors, metadata=None):
+        self.api_key_requests.append(
+            {"name": name, "role_descriptors": role_descriptors, "metadata": metadata}
+        )
+        return {"id": "api-key-id", "api_key": "secret"}
+
+
+class FakeSecureElasticsearch(FakeElasticsearch):
+    def __init__(self):
+        super().__init__()
+        self.security = FakeSecurity()
+
+
+def test_build_dls_query_allows_only_user_or_catalog_docs():
+    dls_query = memory_store.build_dls_query("bob")
+
+    assert dls_query == {
+        "bool": {
+            "should": [
+                {"term": {"user_id": "bob"}},
+                {"bool": {"must_not": {"exists": {"field": "user_id"}}}},
+            ],
+            "minimum_should_match": 1,
+        }
+    }
+
+
+def test_build_api_key_role_descriptor_embeds_dls_query():
+    descriptor = memory_store.build_user_api_key_role_descriptor("bob")
+
+    indices = descriptor["atlas_memory_bob"]["indices"][0]
+    assert indices["names"] == memory_store.MEMORY_INDICES
+    assert indices["privileges"] == ["read", "view_index_metadata"]
+    assert indices["query"] == memory_store.build_dls_query("bob")
+
+
+def test_create_user_api_key_uses_role_descriptor_and_metadata():
+    client = FakeSecureElasticsearch()
+
+    response = memory_store.create_user_api_key(client, "bob")
+
+    assert response == {"id": "api-key-id", "api_key": "secret"}
+    assert client.security.api_key_requests == [
+        {
+            "name": "atlas-memory-bob",
+            "role_descriptors": memory_store.build_user_api_key_role_descriptor("bob"),
+            "metadata": {"user_id": "bob", "purpose": "atlas-memory"},
+        }
+    ]
+
+
+def test_bootstrap_users_creates_indices_and_dls_keys_for_each_user():
+    client = FakeSecureElasticsearch()
+
+    with patch.object(bootstrap_users_module, "create_client", return_value=client):
+        result = bootstrap_users_module.bootstrap_users("http://localhost:9200", ["bob", "alice"])
+
+    assert set(result) == {"bob", "alice"}
+    assert set(client.indices.created) == set(memory_store.MEMORY_INDICES)
+    assert [request["name"] for request in client.security.api_key_requests] == [
+        "atlas-memory-bob",
+        "atlas-memory-alice",
+    ]
+    assert client.security.api_key_requests[1]["role_descriptors"] == (
+        memory_store.build_user_api_key_role_descriptor("alice")
+    )
+
+
+def test_bootstrap_users_requires_at_least_one_user():
+    try:
+        bootstrap_users_module.bootstrap_users("http://localhost:9200", [])
+    except ValueError as exc:
+        assert str(exc) == "At least one user_id is required."
+    else:
+        raise AssertionError("Expected ValueError")
+
+
+def test_ensure_memory_indices_creates_real_elasticsearch_mappings():
+    client = FakeElasticsearch()
+
+    created = memory_store.ensure_memory_indices(client)
+
+    assert created == memory_store.MEMORY_INDICES
+    semantic_mapping = client.indices.created["atlas-semantic"]["mappings"]["properties"]
+    assert semantic_mapping["text"]["type"] == "text"
+    assert semantic_mapping["user_id"]["type"] == "keyword"
+    assert semantic_mapping["confidence"]["type"] == "float"
+    assert semantic_mapping["superseded_by"]["type"] == "keyword"
+
+
+def test_ensure_memory_indices_can_recreate_demo_indices():
+    client = FakeElasticsearch()
+    memory_store.ensure_memory_indices(client)
+
+    memory_store.ensure_memory_indices(client, recreate=True)
+
+    assert client.indices.deleted == [
+        {"index": "atlas-episodic", "ignore_unavailable": True},
+        {"index": "atlas-semantic", "ignore_unavailable": True},
+        {"index": "atlas-procedural", "ignore_unavailable": True},
+        {"index": "atlas-catalog", "ignore_unavailable": True},
+    ]
+
+
+def test_write_memory_preserves_extended_fields_and_refreshes_immediately():
+    client = FakeElasticsearch()
+
+    doc_id = memory_store.write_memory(
+        client,
+        {
+            "user_id": "bob",
+            "text": "Bob prefers concise deployment summaries.",
+            "memory_type": "semantic",
+            "confidence": 0.9,
+            "supersedes": "old_fact",
+            "metadata": {"source": "conversation"},
+        },
+        "atlas-semantic",
+    )
+
+    stored = client.documents[("atlas-semantic", doc_id)]
+    assert stored["confidence"] == 0.9
+    assert stored["supersedes"] == "old_fact"
+    assert stored["metadata"] == {"source": "conversation"}
+    assert client.index_calls[0]["refresh"] is True
+
+
+def test_recall_memory_filters_superseded_docs_by_default():
+    client = FakeElasticsearch()
+    old_id = memory_store.write_memory(
+        client,
+        {"user_id": "bob", "text": "Bob uses Grafana.", "superseded_by": "new"},
+        "atlas-semantic",
+    )
+    new_id = memory_store.write_memory(
+        client,
+        {"user_id": "bob", "text": "Bob uses Kibana."},
+        "atlas-semantic",
+    )
+
+    results = memory_store.recall_memory(client, "bob", "observability dashboard", k=5)
+
+    assert [result["id"] for result in results] == [new_id]
+    assert old_id not in [result["id"] for result in results]
+    assert recall_bool_query(client.search_calls[0]["body"])["must_not"] == [
+        {"exists": {"field": "superseded_by"}}
+    ]
+
+
+def test_recall_memory_can_include_superseded_docs_for_history():
+    client = FakeElasticsearch()
+    old_id = memory_store.write_memory(
+        client,
+        {"user_id": "bob", "text": "Bob used MySQL in 2023.", "superseded_by": "new"},
+        "atlas-semantic",
+    )
+    new_id = memory_store.write_memory(
+        client,
+        {"user_id": "bob", "text": "Bob uses PostgreSQL in 2026."},
+        "atlas-semantic",
+    )
+
+    results = memory_store.recall_memory(
+        client,
+        "bob",
+        "database preference history",
+        k=5,
+        include_superseded=True,
+    )
+
+    assert {result["id"] for result in results} == {old_id, new_id}
+    assert "must_not" not in recall_bool_query(client.search_calls[0]["body"])
+
+
+def test_recall_query_uses_app_layer_user_or_catalog_filter_and_catalog_prior():
+    body = memory_store.build_recall_query("bob", "deployment logs")
+
+    bool_query = recall_bool_query(body)
+    assert bool_query["filter"] == [memory_store.build_user_or_catalog_filter("bob")]
+    assert body["query"]["function_score"]["functions"] == [
+        {
+            "filter": {"term": {"_index": memory_store.CATALOG_INDEX}},
+            "weight": memory_store.CATALOG_SOURCE_PRIOR,
+        }
+    ]
+    assert body["query"]["function_score"]["boost_mode"] == "multiply"
+
+
+def test_supersede_fact_creates_new_fact_and_marks_old_fact():
+    client = FakeElasticsearch()
+    old_id = memory_store.write_memory(
+        client,
+        {"user_id": "bob", "text": "Bob prefers weekly deployment summaries."},
+        "atlas-semantic",
+    )
+
+    new_id = memory_store.supersede_fact(
+        client,
+        user_id="bob",
+        old_fact_id=old_id,
+        new_text="Bob prefers daily deployment summaries.",
+        contradiction_type="harsh",
+    )
+
+    new_doc = client.documents[("atlas-semantic", new_id)]
+    assert new_doc["confidence"] == 0.9
+    assert new_doc["supersedes"] == old_id
+    assert client.updated == [
+        {
+            "index": "atlas-semantic",
+            "id": old_id,
+            "body": {"doc": {"superseded_by": new_id, "superseded_at": "now"}},
+        }
+    ]
+
+
+def test_supersede_fact_supports_chained_history():
+    client = FakeElasticsearch()
+    first_id = memory_store.write_memory(
+        client,
+        {"user_id": "bob", "text": "Bob prefers MySQL."},
+        "atlas-semantic",
+    )
+
+    second_id = memory_store.supersede_fact(
+        client,
+        user_id="bob",
+        old_fact_id=first_id,
+        new_text="Bob prefers PostgreSQL.",
+    )
+    third_id = memory_store.supersede_fact(
+        client,
+        user_id="bob",
+        old_fact_id=second_id,
+        new_text="Bob prefers PostgreSQL with pgvector.",
+    )
+
+    first_doc = client.documents[("atlas-semantic", first_id)]
+    second_doc = client.documents[("atlas-semantic", second_id)]
+    third_doc = client.documents[("atlas-semantic", third_id)]
+    assert first_doc["superseded_by"] == second_id
+    assert second_doc["supersedes"] == first_id
+    assert second_doc["superseded_by"] == third_id
+    assert third_doc["supersedes"] == second_id
+
+
+def test_verbatim_pre_recall_uses_original_exact_tokens_before_llm_rewrite():
+    client = FakeElasticsearch()
+    memory_store.write_memory(
+        client,
+        {
+            "user_id": "bob",
+            "text": "Fix postgres v15.3 + pgvector 0.5.1 index recall issue.",
+            "memory_type": "message",
+        },
+        "atlas-episodic",
+    )
+
+    class RewritingLLM:
+        def __init__(self):
+            self.messages = []
+
+        def chat(self, messages):
+            self.messages = messages
+            return "ok"
+
+    llm = RewritingLLM()
+    agent = pre_recall.MemoryAwareAgent(client, llm, "bob")
+
+    agent.run_turn("postgres v15.3 + pgvector 0.5.1 failed again", "turn-123456")
+
+    search_query = recall_bool_query(client.search_calls[0]["body"])["should"][0]["multi_match"]["query"]
+    tool_arguments = llm.messages[0]["tool_calls"][0]["function"]["arguments"]
+    assert search_query == "postgres v15.3 + pgvector 0.5.1 failed again"
+    assert "postgres v15.3 + pgvector 0.5.1 failed again" in tool_arguments
+
+
+def test_gbrain_use_case_returns_response_and_supersedes_stale_fact():
+    client = FakeElasticsearch()
+
+    result = gbrain.run_deployment_memory_use_case(client)
+
+    assert "Kibana" in result["assistant_response"]
+    assert "concise" in result["assistant_response"]
+    assert result["new_fact_id"] is not None
+    memory_types = {memory["memory_type"] for memory in result["recalled_memories"]}
+    assert {"message", "semantic", "procedural"}.issubset(memory_types)
+    superseded_updates = [update for update in client.updated if update["index"] == "atlas-semantic"]
+    assert len(superseded_updates) == 1


### PR DESCRIPTION
## Summary
- Add an Elasticsearch-backed Agent Memory sample under 19-ElasticSearch/Agent-Memory.
- Include memory writes, mixed-type recall, verbatim pre-recall, consolidation guidance, soft supersession, and a runnable deployment-log use case.
- Add DLS multi-tenant support with per-user API-key role descriptors, a bootstrap script, redundant app-layer filtering, and a soft catalog ranking prior.

## Validation
- python -m pytest 19-ElasticSearch/Agent-Memory/test_agent_memory.py -q -> 15 passed
- python -m py_compile across Agent-Memory scripts -> exit 0

## Notes
- The live Elasticsearch demo expects a local ES cluster. Tests use a fake client to validate query and API-key request shapes without Docker.